### PR TITLE
Use FQCNs for the new listeners

### DIFF
--- a/core-bundle/src/Resources/config/listener.yml
+++ b/core-bundle/src/Resources/config/listener.yml
@@ -380,15 +380,34 @@ services:
             - { name: kernel.reset, method: reset }
 
     contao.listener.switch_user:
-        class: Contao\CoreBundle\EventListener\Security\SwitchUserListener
+        alias: Contao\CoreBundle\EventListener\Security\SwitchUserListener
+        deprecated:
+            package: contao/core-bundle
+            version: 4.13
+            message: Using the "%alias_id%" service ID has been deprecated and will no longer work in Contao 5.0. Please use "Contao\CoreBundle\EventListener\Security\SwitchUserListener" instead.
+
+    contao.listener.two_factor.frontend:
+        alias: Contao\CoreBundle\EventListener\Security\TwoFactorFrontendListener
+        deprecated:
+            package: contao/core-bundle
+            version: 4.13
+            message: Using the "%alias_id%" service ID has been deprecated and will no longer work in Contao 5.0. Please use "Contao\CoreBundle\EventListener\Security\TwoFactorFrontendListener" instead.
+
+    Contao\CoreBundle\EventListener\Security\LogoutSuccessListener:
+        arguments:
+            - '@security.http_utils'
+            - '@contao.routing.scope_matcher'
+        tags:
+            - kernel.event_listener
+
+    Contao\CoreBundle\EventListener\Security\SwitchUserListener:
         arguments:
             - '@security.token_storage'
             - '@logger'
         tags:
             - kernel.event_listener
 
-    contao.listener.two_factor.frontend:
-        class: Contao\CoreBundle\EventListener\Security\TwoFactorFrontendListener
+    Contao\CoreBundle\EventListener\Security\TwoFactorFrontendListener:
         arguments:
             - '@contao.framework'
             - '@contao.routing.scope_matcher'
@@ -404,12 +423,5 @@ services:
             - '@security.helper'
             - '@contao.routing.scope_matcher'
             - '@event_dispatcher'
-        tags:
-            - kernel.event_listener
-
-    Contao\CoreBundle\EventListener\Security\LogoutSuccessListener:
-        arguments:
-            - '@security.http_utils'
-            - '@contao.routing.scope_matcher'
         tags:
             - kernel.event_listener

--- a/core-bundle/src/Security/Logout/LogoutSuccessHandler.php
+++ b/core-bundle/src/Security/Logout/LogoutSuccessHandler.php
@@ -19,8 +19,8 @@ use Symfony\Component\Security\Http\HttpUtils;
 use Symfony\Component\Security\Http\Logout\DefaultLogoutSuccessHandler;
 
 /**
- * @deprecated using this success handler is deprecated;
- *             register a listener on the "Symfony\Component\Security\Http\Event\LogoutEvent" event instead
+ * @deprecated Deprecated since Contao 4.13, to be removed in Contao 5.0; use
+ *             the Symfony\Component\Security\Http\Event\LogoutEvent event instead
  */
 class LogoutSuccessHandler extends DefaultLogoutSuccessHandler
 {

--- a/core-bundle/tests/EventListener/Security/LogoutSuccessListenerTest.php
+++ b/core-bundle/tests/EventListener/Security/LogoutSuccessListenerTest.php
@@ -26,6 +26,7 @@ class LogoutSuccessListenerTest extends TestCase
     public function testReturnsIfResponseIsAlreadySet(): void
     {
         $response = new Response();
+
         $event = new LogoutEvent(new Request(), null);
         $event->setResponse($response);
 


### PR DESCRIPTION
Not sure if we would be allowed to delete the old service IDs instead of deprecating them? After all, our listeners are internal.