### PR TITLE
Extend from AbstractFrontendModuleController

### DIFF
--- a/core-bundle/src/Controller/FrontendModule/RootPageDependentModulesController.php
+++ b/core-bundle/src/Controller/FrontendModule/RootPageDependentModulesController.php
@@ -21,8 +21,12 @@ use Symfony\Component\HttpFoundation\Response;
 
 class RootPageDependentModulesController extends AbstractFrontendModuleController
 {
-    public function getResponse(Template $template, ModuleModel $model, Request $request): Response
+    public function __invoke(Request $request, ModuleModel $model, string $section, array $classes = null): Response
     {
+        if ($this->container->get('contao.routing.scope_matcher')->isBackendRequest($request)) {
+            return $this->getBackendWildcard($model);
+        }
+
         if (!$pageModel = $this->getPageModel()) {
             return new Response('');
         }
@@ -36,6 +40,13 @@ class RootPageDependentModulesController extends AbstractFrontendModuleControlle
         $controller = $this->container->get('contao.framework')->getAdapter(Controller::class);
         $content = $controller->getFrontendModule($modules[$pageModel->rootId]);
 
+        $this->tagResponse($model);
+
         return new Response($content);
+    }
+
+    public function getResponse(Template $template, ModuleModel $model, Request $request): Response
+    {
+        throw new \LogicException('This method should never be called');
     }
 }

--- a/core-bundle/src/Controller/FrontendModule/RootPageDependentModulesController.php
+++ b/core-bundle/src/Controller/FrontendModule/RootPageDependentModulesController.php
@@ -13,15 +13,15 @@ declare(strict_types=1);
 namespace Contao\CoreBundle\Controller\FrontendModule;
 
 use Contao\Controller;
-use Contao\CoreBundle\Controller\AbstractFragmentController;
 use Contao\ModuleModel;
 use Contao\StringUtil;
+use Contao\Template;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
-class RootPageDependentModulesController extends AbstractFragmentController
+class RootPageDependentModulesController extends AbstractFrontendModuleController
 {
-    public function __invoke(Request $request, ModuleModel $model, string $section, array $classes = null): Response
+    public function getResponse(Template $template, ModuleModel $model, Request $request): Response
     {
         if (!$pageModel = $this->getPageModel()) {
             return new Response('');
@@ -35,8 +35,6 @@ class RootPageDependentModulesController extends AbstractFragmentController
 
         $controller = $this->container->get('contao.framework')->getAdapter(Controller::class);
         $content = $controller->getFrontendModule($modules[$pageModel->rootId]);
-
-        $this->tagResponse($model);
 
         return new Response($content);
     }


### PR DESCRIPTION
IMHO the `RootPageDependentModulesController` should extend the `AbstractFrontendModuleController`, so things like response tagging and the back end preview are handled automatically.

<img width="414" alt="" src="https://user-images.githubusercontent.com/1192057/149760347-e397c27b-50d5-4597-9ed5-f6e4dcbf5b66.png">
